### PR TITLE
A qtree should autorequire its volume

### DIFF
--- a/lib/puppet/type/netapp_qtree.rb
+++ b/lib/puppet/type/netapp_qtree.rb
@@ -25,4 +25,8 @@ Puppet::Type.newtype(:netapp_qtree) do
       end
     end   
   end
+
+  autorequire(:netapp_volume) do
+    self[:volume]
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,8 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 Dir[File.join(File.dirname(__FILE__), 'support', '*.rb')].each do |support_file|
   require support_file
 end
+
+class Object
+  alias :must :should
+  alias :must_not :should_not
+end


### PR DESCRIPTION
A qtree is always created on a specific volume so if you handle both the qtree and the volume with puppet, we should establish an autorequire.

Please only merge the spec changes that you like. You have used the shared_example functionality of rspec and I did not to be more verbose about which kind of values I'm checking against.

I don't know what's the best approach here so feel free to change that part.
